### PR TITLE
Use the team name variable in the AKS and ACR name

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -135,13 +135,13 @@
         "virtualMachineContributorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
         "readerRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
 
-        "subRgUniqueString": "[uniqueString('aks', subscription().subscriptionId, resourceGroup().id)]",
+        "subRgUniqueString": "[take(uniqueString('aks', subscription().subscriptionId, resourceGroup().id), 8)]",
 
         "nodeResourceGroupName": "[concat('rg-', parameters('asbTeamName'), '-nodepools')]",
-        "clusterName": "[concat('aks-', variables('subRgUniqueString'))]",
+        "clusterName": "[concat('aks-', variables('subRgUniqueString'), '-', parameters('asbTeamName'))]",
         "logAnalyticsWorkspaceName": "[concat('la-', variables('clusterName'))]",
         "containerInsightsSolutionName": "[concat('ContainerInsights(', variables('logAnalyticsWorkspaceName'),')')]",
-        "defaultAcrName": "[concat('acraks', variables('subRgUniqueString'))]",
+        "defaultAcrName": "[concat('acraks', variables('subRgUniqueString'), parameters('asbTeamName'))]",
 
         "vNetResourceGroup": "[split(parameters('targetVnetResourceId'),'/')[4]]",
         "vnetName": "[split(parameters('targetVnetResourceId'),'/')[8]]",

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -138,10 +138,10 @@
         "subRgUniqueString": "[take(uniqueString('aks', subscription().subscriptionId, resourceGroup().id), 8)]",
 
         "nodeResourceGroupName": "[concat('rg-', parameters('asbTeamName'), '-nodepools')]",
-        "clusterName": "[concat('aks-', variables('subRgUniqueString'), '-', parameters('asbTeamName'))]",
+        "clusterName": "[concat('aks-', parameters('asbTeamName'), '-', variables('subRgUniqueString'))]",
         "logAnalyticsWorkspaceName": "[concat('la-', variables('clusterName'))]",
         "containerInsightsSolutionName": "[concat('ContainerInsights(', variables('logAnalyticsWorkspaceName'),')')]",
-        "defaultAcrName": "[concat('acraks', variables('subRgUniqueString'), parameters('asbTeamName'))]",
+        "defaultAcrName": "[concat('acraks', parameters('asbTeamName'), variables('subRgUniqueString'))]",
 
         "vNetResourceGroup": "[split(parameters('targetVnetResourceId'),'/')[4]]",
         "vnetName": "[split(parameters('targetVnetResourceId'),'/')[8]]",


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Updated the variables for AKS and ACR names to include `ASB_TEAM_NAME`.
Key Vault uses the cluster name. So `subRgUniqueString` was trimmed down to 8 character to keep the generated key vault name under the 24 character Azure limit. The idea is that keeping some of the unique string can still be helpful in a hackathon setting for reducing the risk of naming conflicts.

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/aks-secure-baseline-hack-template/issues/55